### PR TITLE
Add beginCapture and endCapture

### DIFF
--- a/VerbalExpressions.js
+++ b/VerbalExpressions.js
@@ -48,7 +48,6 @@ window.VerbalExpression = (function(){
  
     };
  
- 
     // Define the class methods.
     VerbalExpression.prototype = {
         
@@ -99,7 +98,7 @@ window.VerbalExpression = (function(){
         // naturally.
         then : function( value ) {
             value = this.sanitize( value );
-            this.add( "(" + value + ")" );
+            this.add( "(?:" + value + ")" );
             return( this );
         },
         
@@ -114,20 +113,20 @@ window.VerbalExpression = (function(){
         // Maybe is used to add values with ?
         maybe : function( value ) {
             value = this.sanitize(value);
-            this.add( "(" + value + ")?" );
+            this.add( "(?:" + value + ")?" );
             return( this );
         },
         
         // Any character any number of times
         anything : function() {
-            this.add( "(.*)" );
+            this.add( "(?:.*)" );
             return( this );
         },
         
         // Anything but these characters
         anythingBut : function( value ) {
             value = this.sanitize( value );
-            this.add( "([^" + value + "]*)" );
+            this.add( "(?:[^" + value + "]*)" );
             return( this );
         },
         
@@ -147,7 +146,7 @@ window.VerbalExpression = (function(){
         
         // Line break
         lineBreak : function() {
-            this.add( "(\\n|(\\r\\n))" ); // Unix + windows CLRF
+            this.add( "(?:\\n|(?:\\r\\n))" ); // Unix + windows CLRF
             return( this );
         },
         // And a shorthand for html-minded
@@ -274,11 +273,29 @@ window.VerbalExpression = (function(){
         // Adds alternative expressions
         or : function( value ) {
             
-            if(this._prefixes.indexOf("(") == -1) this._prefixes += "(";
-            if(this._suffixes.indexOf(")") == -1) this._suffixes = ")" + this._suffixes;
+            this._prefixes += "(?:";
+            this._suffixes = ")" + this._suffixes;
             
-            this.add( ")|(" );
+            this.add( ")|(?:" );
             if(value) this.then( value );
+            
+            return( this );
+        },
+
+        //starts a capturing group
+        beginCapture : function() {
+            //add the end of the capture group to the suffixes for now so compilation continues to work
+            this._suffixes += ")";
+            this.add( "(", false );
+
+            return( this );
+        },
+
+        //ends a capturing group
+        endCapture : function() {
+						//remove the last parentheses from the _suffixes and add to the regex itself
+            this._suffixes = this._suffixes.substring(0, this._suffixes.length - 1 );
+            this.add( ")", true );
             
             return( this );
         }


### PR DESCRIPTION
Hi,

First off, this tool is a great idea!!!

About this PR:

I added `beginCapture` and `endCapture` functions to support capturing groups.  Here is an example:

``` javascript
var tester = VerEx()
            .startOfLine().beginCapture()
            .then( "http" )
            .maybe( "s" ).endCapture()
            .then( "://" )
            .maybe( "www." ).beginCapture()
            .anythingBut( " " ).endCapture()
            .endOfLine();

var matches = tester.exec("https://www.google.com")
//matches: ["https://www.google.com", "https", "google.com"]
```

To achieve this, I also changed all other `(` used in the code to non-capturing ones `(?:` so that the regex wouldn't capture anything the user did not expect.

Please be sure to review my changes to the `or` function since I removed the extra check on `this._prefixes` and `this._suffixes` because I couldn't quite figure out what usecase those were addressing.

Overall, this pattern is a slight divergence from what you have going right now in that it takes two function calls to achieve something.  The other option would be to make it more like `or()` behaves and have a `capture()` function that just captures everything before it.  However, I think `beginCapture()`/`endCapture()` is a bit more flexible and allows you to have multiple separate capturing groups which is probably pretty common.

Please let me know what you think.  I'd be happy to add info to `README.md` and the wiki if you plan on merging it.

Thanks,
Oleg

PS - If you like these functions, I was thinking we could even take it a step further and allow users to pass in a `name` into `beginCapture` and then provide a more user-friendly way of accessing the captured values than the array returned by `exec()`.
