### PR TITLE
C++port

### DIFF
--- a/verbalexpressions.hpp
+++ b/verbalexpressions.hpp
@@ -1,6 +1,6 @@
 /*!
  * VerbalExpressions C++ Library v0.1
- * https://github.com/whackashoe/C++VerbalExpressions
+ * https://github.com/whackashoe/CppVerbalExpressions
  *
  * The MIT License (MIT)
  * 


### PR DESCRIPTION
- `or` is changed to `alt` due to it being a restricted keyword
- The modifiers are somewhat different, due to the differences in flags that it supports.
- There is an external dependency on boost_regex that will go away once c++ has a working regex implementation in gcc and libstdc++.

I also have this with and example script and makefile @ https://github.com/whackashoe/CppVerbalExpressions, if you like I can add them to branch. 
