### PR TITLE
Removes a console.log

### DIFF
--- a/VerbalExpressions.js
+++ b/VerbalExpressions.js
@@ -197,7 +197,6 @@
         range : function() {
             
             var value = "[";
-            console.log(arguments);
             
             for(var _from = 0; _from < arguments.length; _from += 2) {
                 var _to = _from+1;


### PR DESCRIPTION
Ran into this console.log in `range` while testing a regex in the console, figured it was probably just leftover debug code :)
