### PR TITLE
Simplify object creation

### DIFF
--- a/VerbalExpressions.js
+++ b/VerbalExpressions.js
@@ -17,10 +17,7 @@
 
     // I am the constructor function.
     function VerbalExpression(){
-        var verbalExpression = Object.create( RegExp.prototype );
-        
-        // Initialize 
-        verbalExpression = (RegExp.apply( verbalExpression, arguments ) || verbalExpression);
+        var verbalExpression = new RegExp();
      
         // Add all the class methods
         VerbalExpression.injectClassMethods( verbalExpression );


### PR DESCRIPTION
Currently new `RegExp` creation is pretty obscure. It may be replaced by less complex statment.

Rationale:

``` javascript
var verbalExpression = Object.create( RegExp.prototype );
// New object is created. [[class]] = 'Object', [[prototype]] = RegExp.prototype
// It has same prorotype as RegExp, but this is not RegExp.
// Also, Object.create is unavailable for older browsers

verbalExpression = (
    RegExp.apply( verbalExpression, arguments )
// If arguments[0] is regexp, it would return arguments[0]
// Otherwise it would just create new RegExp using args[0] as pattern and args[1] as flags.
// Pattern will be overwritten upon next .compile call, so it is pretty useless to set anything here.
    || verbalExpression
// RegExp always returns object, so || is always short-circuited
);
```
