### PR TITLE
Do not try to call .replace() on a number

### DIFF
--- a/VerbalExpressions.js
+++ b/VerbalExpressions.js
@@ -65,6 +65,7 @@
         // anything safely to the expression
         sanitize : function( value ) {
             if(value.source) return value.source;
+            if(typeof value === "number") return value;
             return value.replace(/[^\w]/g, function(character) { return "\\" + character; });
         },
         


### PR DESCRIPTION
When using range, for example, it makes sense to allow this type of syntax `.range(1, 10)` which is currently throwing a type error.
