### PR TITLE
added toRegExp() method

### DIFF
--- a/VerbalExpressions.js
+++ b/VerbalExpressions.js
@@ -312,6 +312,12 @@
             this.add( ")", true );
             
             return( this );
+        },
+
+        //convert to RegExp object
+        toRegExp : function() {
+            var arr = this.toString().match(/\/(.*)\/([a-z]+)?/);
+            return new RegExp(arr[1],arr[2]);
         }
         
     };


### PR DESCRIPTION
Added a `toRegExp()` method that will convert from a VerbalExpression object to a plain old RegExp. 

This is especially useful for libraries like [Cucumber.js](https://github.com/cucumber/cucumber-js) that expect a plain RegExp (with no additional methods like `replace()`)
