### PR TITLE
Set up aliases for grunt tasks in package.json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,4 @@ language: node_js
 node_js:
   - "0.10"
 
-before_script:
-  - npm install -g grunt-cli
-
-script: grunt test --verbose
+script: npm run test:verbose

--- a/README.md
+++ b/README.md
@@ -41,15 +41,15 @@ var VerEx = require('verbal-expressions');
 
 ## Running tests
 
-    $ grunt
+    $ npm run grunt
     (or)
-    $ grunt test
+    $ npm test
 
 ## Creating a minified version
 
 This will generate a minified version of VerbalExpressions.js (aptly named VerbalExpressions.min.js) in a _dist_ folder.
 
-    $ grunt build
+    $ npm run build
 
 A source map will also be created in the same folder, so you can use the original unminified source file (copied to _dist_ as well) for debugging purposes.
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "eslint": "^1.10.3",
     "eslint-config-airbnb": "^3.1.0",
     "grunt": "^0.4.2",
+    "grunt-cli": "^0.1.13",
     "grunt-contrib-copy": "^0.8.2",
     "grunt-contrib-qunit": "^0.7.0",
     "grunt-contrib-uglify": "^0.11.0",
@@ -28,6 +29,11 @@
   "license": {
     "type": "MIT",
     "url": "http://opensource.org/licenses/MIT"
+  },
+  "scripts": {
+    "grunt": "grunt",
+    "test": "grunt test",
+    "build": "grunt build"
   },
   "engines": {
     "node": ">= 0.8.0"

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "scripts": {
     "grunt": "grunt",
     "test": "grunt test",
+    "test:verbose": "grunt test --verbose",
     "build": "grunt build"
   },
   "engines": {


### PR DESCRIPTION
Contributors shouldn't need to install grunt / grunt-cli globally in order to run tests and/or build the project. This adds the `grunt-cli` npm package to devDependencies and sets up aliases for the main grunt tasks (default, test and build) in the "scripts" section  of the package.json

Also updates the README to use these aliases in the documentation.