### PR TITLE
Update package.json to enable installation of typescript declaration file

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "build": "grunt build",
     "docs": "grunt docs"
   },
+  "types": "./typings/verbalexpression.d.ts",
   "engines": {
     "node": ">= 0.8.0"
   }


### PR DESCRIPTION
According to [docs](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html), adding types to package.json enables publishing declaration file so everyone can install it later via npm install @types/verbal-expressions