### PR TITLE
Fix typings export

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "build": "grunt build",
     "docs": "grunt docs"
   },
-  "types": "./typings/verbalexpression.d.ts",
+  "types": "./typings/VerbalExpressions.d.ts",
   "engines": {
     "node": "^9.2.0"
   },

--- a/typings/VerbalExpressions.d.ts
+++ b/typings/VerbalExpressions.d.ts
@@ -48,4 +48,5 @@ interface VerbalExpressionConstructor {
 }
 
 declare var VerEx: VerbalExpressionConstructor;
+export = VerEx;
 


### PR DESCRIPTION
 - Fix `"types"` in package.json. #166 renamed typings file, breaking that reference.
 - Add necessary `export` declaration. Without it, TypeScript assumes that module doesn't export anything.