### PR TITLE
Remove `.npmignore`

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,0 @@
-.vscode
-verbal_expressions.py
-verbal_expressions.rb
-VerbalExpressions.groovy
-VerbalExpressions.java
-VerbalExpressions.php


### PR DESCRIPTION
Useless folders like `.nyc_output` and `.vscode` are being included in
the npm bundle as can be seen at
https://www.jsdelivr.com/package/npm/verbal-expressions?version=1.0.0.
Since `.npmignore` replaces rather than extends `.gitignore` for files
being ignored by npm (per
https://docs.npmjs.com/misc/developers#keeping-files-out-of-your-package),
these folders will not be ignored by npm unless we explicitly add them
to `.npmignore`. Since at the moment we don't have many discrepancies
between files to be ignored by git and those to be ignored by npm, I
feel it's best to get rid of `.npmignore` and have to maintain just a
`.gitignore`.