### PR TITLE
Change ci to GitHub actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,16 @@
+name: Run tests
+on: pull_request
+jobs:
+    test:
+        name: Run tests on Node.js ${{ matrix.node-version }}
+        runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                node-version: ['15', '14', '13', '12', '11', '10']
+        steps:
+            - uses: actions/checkout@v2
+            - uses: actions/setup-node@v1
+              with:
+                  node-version: ${{ matrix.node-version }}
+            - run: npm ci
+            - run: npm run test:verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: node_js
-
-node_js:
-    - "10"
-    - "11"
-    - "12"
-
-script: npm run test:verbose


### PR DESCRIPTION
~Depends on #206~

Travis has grown awfully sluggish nowadays, and Github has a decent CI system so removing Travis now to make our CI run faster

(Actions doesn't seem to work from a fork at #207, so trying out directly a PR from this repo)