### PR TITLE
Add Ruby deps to dependabot auto-merge

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -7,3 +7,10 @@ update_configs:
       - match:
           dependency_type: 'all'
           update_type: 'all'
+  - package_manager: 'ruby'
+    directory: '/docs'
+    update_schedule: 'live'
+    automerged_updates:
+      - match:
+          dependency_type: 'all'
+          update_type: 'all'


### PR DESCRIPTION
Opening as draft until Dependabot indexes the initial config